### PR TITLE
Benchfella module to compare with exmatrix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ erl_crash.dump
 
 /native/obj
 /native/bin
+
+/bench/graphs
+/bench/snapshots
+
+.DS_Store

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -13,7 +13,40 @@ end
 defmodule MatrixBench do
   @moduledoc """
   Benchfella module to compare matrix operations performance with a115/exmatrix
+
+  Below are results for MacBookPro, 8 cores, 16 GB memory.
+  ExLearn used only a fraction of CPU, because it does not use parallel computation.
+  So, actual performance advantage of ExLearn will be an order of magnitude greater.
+
+  ## ExMatrix
+
+  Finished in 29.04 seconds
+
+  benchmark name                iterations   average time
+  transpose a 100x100 matrix        5000   719.77 µs/op
+  transpose a 200x200 matrix         500   2828.41 µs/op
+  transpose a 400x400 matrix         100   14057.79 µs/op
+  50x50 matrix in parallel            50   29563.38 µs/op
+  100x100 matrix in parallel          10   195277.70 µs/op
+  200x200 matrix in parallel           1   1585938.00 µs/op
+  400x400 matrix in parallel           1   15745453.00 µs/op
+
+
+  ## ExLearn.Matrix
+
+  Finished in 19.57 seconds
+
+  benchmark name                iterations   average time
+  transpose a 100x100 matrix        100000   27.47 µs/op
+  50x50 matrices dot product         20000   95.70 µs/op
+  transpose a 200x200 matrix         10000   120.89 µs/op
+  transpose a 400x400 matrix          5000   418.17 µs/op
+  100x100 matrices dot product        5000   674.94 µs/op
+  200x200 matrices dot product         500   4998.85 µs/op
+  400x400 matrices dot product          50   38847.84 µs/op
+
   """
+
   use Benchfella
   import ExLearn.Matrix
   import MatrixBench.RandomMatrix

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -15,10 +15,10 @@ defmodule MatrixBench do
 
   Below are results for MacBookPro, 1 core used, 16 GB memory.
   ExLearn shows about 1 000 times better performance in dot product
-  and is tens times faster in transposing.
+  and is 20 times faster in transposing.
 
   ## ExMatrix
-
+  ```
   Finished in 52.3 seconds
 
   benchmark name                iterations   average time
@@ -29,10 +29,11 @@ defmodule MatrixBench do
   100x100 matrices dot product           2   615565.00 µs/op
   200x200 matrices dot product           1   4383168.00 µs/op
   400x400 matrices dot product           1   34386453.00 µs/op
+  ```
 
 
   ## ExLearn.Matrix
-
+  ```
   Finished in 18.4 seconds
 
   benchmark name                iterations   average time
@@ -43,6 +44,7 @@ defmodule MatrixBench do
   100x100 matrices dot product        5000   622.99 µs/op
   200x200 matrices dot product         500   4652.35 µs/op
   400x400 matrices dot product          50   36277.00 µs/op
+  ```
   """
 
   use Benchfella

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -19,7 +19,7 @@ defmodule MatrixBench do
 
   ## ExMatrix
 
-  Finished in 53.23 seconds
+  Finished in 52.3 seconds
 
   benchmark name                iterations   average time
   transpose a 100x100 matrix          5000   763.27 µs/op

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -11,6 +11,9 @@ end
 
 
 defmodule MatrixBench do
+  @moduledoc """
+  Benchfella module to compare matrix operations performance with a115/exmatrix
+  """
   use Benchfella
   import ExLearn.Matrix
   import MatrixBench.RandomMatrix

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -4,7 +4,6 @@ defmodule MatrixBench.RandomMatrix do
     """
     @spec random(integer, integer, integer) :: [[number]]
     def random(rows, cols, max) do
-      IO.puts "Random #{rows}, #{cols}."
       ExLearn.Matrix.new(rows, cols, fn -> :rand.uniform(max) end)
     end
 end
@@ -14,37 +13,36 @@ defmodule MatrixBench do
   @moduledoc """
   Benchfella module to compare matrix operations performance with a115/exmatrix
 
-  Below are results for MacBookPro, 8 cores, 16 GB memory.
-  ExLearn used only a fraction of CPU, because it does not use parallel computation.
-  So, actual performance advantage of ExLearn will be an order of magnitude greater.
+  Below are results for MacBookPro, 1 core used, 16 GB memory.
+  ExLearn shows about 1 000 times better performance in dot product
+  and is tens times faster in transposing.
 
   ## ExMatrix
 
-  Finished in 29.04 seconds
+  Finished in 53.23 seconds
 
   benchmark name                iterations   average time
-  transpose a 100x100 matrix        5000   719.77 µs/op
-  transpose a 200x200 matrix         500   2828.41 µs/op
-  transpose a 400x400 matrix         100   14057.79 µs/op
-  50x50 matrix in parallel            50   29563.38 µs/op
-  100x100 matrix in parallel          10   195277.70 µs/op
-  200x200 matrix in parallel           1   1585938.00 µs/op
-  400x400 matrix in parallel           1   15745453.00 µs/op
+  transpose a 100x100 matrix          5000   763.27 µs/op
+  transpose a 200x200 matrix          1000   2704.82 µs/op
+  transpose a 400x400 matrix           100   13543.31 µs/op
+  50x50 matrices dot product            20   79386.05 µs/op
+  100x100 matrices dot product           2   615565.00 µs/op
+  200x200 matrices dot product           1   4383168.00 µs/op
+  400x400 matrices dot product           1   34386453.00 µs/op
 
 
   ## ExLearn.Matrix
 
-  Finished in 19.57 seconds
+  Finished in 18.4 seconds
 
   benchmark name                iterations   average time
-  transpose a 100x100 matrix        100000   27.47 µs/op
-  50x50 matrices dot product         20000   95.70 µs/op
-  transpose a 200x200 matrix         10000   120.89 µs/op
-  transpose a 400x400 matrix          5000   418.17 µs/op
-  100x100 matrices dot product        5000   674.94 µs/op
-  200x200 matrices dot product         500   4998.85 µs/op
-  400x400 matrices dot product          50   38847.84 µs/op
-
+  transpose a 100x100 matrix        100000   26.28 µs/op
+  50x50 matrices dot product         20000   89.86 µs/op
+  transpose a 200x200 matrix         10000   116.80 µs/op
+  transpose a 400x400 matrix          5000   405.55 µs/op
+  100x100 matrices dot product        5000   622.99 µs/op
+  200x200 matrices dot product         500   4652.35 µs/op
+  400x400 matrices dot product          50   36277.00 µs/op
   """
 
   use Benchfella

--- a/bench/matrix_bench.exs
+++ b/bench/matrix_bench.exs
@@ -1,0 +1,54 @@
+defmodule MatrixBench.RandomMatrix do
+    @doc """
+    Generates a random matrix just so we can test large matrices
+    """
+    @spec random(integer, integer, integer) :: [[number]]
+    def random(rows, cols, max) do
+      IO.puts "Random #{rows}, #{cols}."
+      ExLearn.Matrix.new(rows, cols, fn -> :rand.uniform(max) end)
+    end
+end
+
+
+defmodule MatrixBench do
+  use Benchfella
+  import ExLearn.Matrix
+  import MatrixBench.RandomMatrix
+
+  @random_a random(50, 50, 100)
+  @random_b random(50, 50, 100)
+  @random_a_large random(100, 100, 100)
+  @random_b_large random(100, 100, 100)
+  @random_a_qlarge random(200, 200, 100)
+  @random_b_qlarge random(200, 200, 100)
+  @random_a_vlarge random(400, 400, 100)
+  @random_b_vlarge random(400, 400, 100)
+
+  bench "transpose a 100x100 matrix" do
+    transpose(@random_a_large)
+  end
+
+  bench "transpose a 200x200 matrix" do
+    transpose(@random_a_qlarge)
+  end
+
+  bench "transpose a 400x400 matrix" do
+    transpose(@random_a_vlarge)
+  end
+
+  bench "50x50 matrices dot product" do
+    dot(@random_a, @random_b)
+  end
+
+  bench "100x100 matrices dot product" do
+    dot(@random_a_large, @random_b_large)
+  end
+
+  bench "200x200 matrices dot product" do
+    dot(@random_a_qlarge, @random_b_qlarge)
+  end
+
+  bench "400x400 matrices dot product" do
+    dot(@random_a_vlarge, @random_b_vlarge)
+  end
+end


### PR DESCRIPTION
Below are results for MacBookPro, 1 core used, 16 GB memory.
  ExLearn shows about 1 000 times better performance in dot product
  and is 20 times faster in transposing.

  ## ExMatrix
```
  Finished in 52.3 seconds

  benchmark name                iterations   average time
  transpose a 100x100 matrix          5000   763.27 µs/op
  transpose a 200x200 matrix          1000   2704.82 µs/op
  transpose a 400x400 matrix           100   13543.31 µs/op
  50x50 matrices dot product            20   79386.05 µs/op
  100x100 matrices dot product           2   615565.00 µs/op
  200x200 matrices dot product           1   4383168.00 µs/op
  400x400 matrices dot product           1   34386453.00 µs/op
```

  ## ExLearn.Matrix
```
  Finished in 18.4 seconds

  benchmark name                iterations   average time
  transpose a 100x100 matrix        100000   26.28 µs/op
  50x50 matrices dot product         20000   89.86 µs/op
  transpose a 200x200 matrix         10000   116.80 µs/op
  transpose a 400x400 matrix          5000   405.55 µs/op
  100x100 matrices dot product        5000   622.99 µs/op
  200x200 matrices dot product         500   4652.35 µs/op
  400x400 matrices dot product          50   36277.00 µs/op
```